### PR TITLE
Fix issue lost braces

### DIFF
--- a/R/count_cases.R
+++ b/R/count_cases.R
@@ -25,7 +25,7 @@
 #' @return A **data.frame** consists of aggregated data.
 #' 
 #' The returned data.frame contains the following columns:
-#' \itemize{
+#' \describe{
 #'   \item{DRUG_TYPE: }{type of the drug, DrugYes for target drug and DrugNo for referenced drug}
 #'   \item{AE_NAME: }{the name of the adverse event}
 #'   \item{AEyes: }{number of observations that have this AE}

--- a/R/enrich.R
+++ b/R/enrich.R
@@ -53,7 +53,7 @@
 #' @return A list containing 2 data.frames named **Final_result** and **AE_info**.
 #' 
 #' The **Final_result** data.frame contains the following columns: 
-#' \itemize{
+#' \describe{
 #'   \item{GROUP_NAME: }{AE group names}
 #'   \item{ES: }{enrichment score}
 #'   \item{p_value: }{p value of the enrichment test}
@@ -61,7 +61,7 @@
 #' }
 #' 
 #' The **AE_info** contains the following columns:
-#' \itemize{
+#' \describe{
 #'   \item{AE_NAME: }{AE names}
 #'   \item{OR: }{odds ratio for each individual AE}
 #'   \item{p_value: }{p value for AE-drug association}

--- a/man/count_cases.Rd
+++ b/man/count_cases.Rd
@@ -45,7 +45,7 @@ for a specific AE. Default 10.}
 A \strong{data.frame} consists of aggregated data.
 
 The returned data.frame contains the following columns:
-\itemize{
+\describe{
 \item{DRUG_TYPE: }{type of the drug, DrugYes for target drug and DrugNo for referenced drug}
 \item{AE_NAME: }{the name of the adverse event}
 \item{AEyes: }{number of observations that have this AE}

--- a/man/enrich.Rd
+++ b/man/enrich.Rd
@@ -71,7 +71,7 @@ for a specific AE.}
 A list containing 2 data.frames named \strong{Final_result} and \strong{AE_info}.
 
 The \strong{Final_result} data.frame contains the following columns:
-\itemize{
+\describe{
 \item{GROUP_NAME: }{AE group names}
 \item{ES: }{enrichment score}
 \item{p_value: }{p value of the enrichment test}
@@ -79,7 +79,7 @@ The \strong{Final_result} data.frame contains the following columns:
 }
 
 The \strong{AE_info} contains the following columns:
-\itemize{
+\describe{
 \item{AE_NAME: }{AE names}
 \item{OR: }{odds ratio for each individual AE}
 \item{p_value: }{p value for AE-drug association}


### PR DESCRIPTION
This pull request addresses documentation issues detected by R CMD check under the “Rd files” check. Specifically, the package help files contained instances of “Lost braces”, where braces were not correctly escaped.

Such issues result in mis-formatted documentation and produce a NOTE on CRAN checks. The problems were identified via the regular CRAN checks on the r-devel-linux-x86_64-debian-gcc platform.

**Changes made**

- count_cases.Rd: Use \describe{} for items.
- enrich.Rd: Use \describe{} for items.
- Corrected unescaped braces in `.Rd` files (or regenerated .Rd files via roxygen2 if applicable).
- Ensured that macros such as `\eqn{}`, `\doi{}`, and `\code{}` are used correctly.
 

**Verified fixes with:**
- ` tools::checkRd()` to confirm syntax validity.
- `tools::Rd2HTML()` to preview rendered documentation.

Confirmed that R CMD check now passes without the previous “Lost braces” NOTE.

**Background**

This task was proposed by R Core developer Kurt Hornik. It is part of an initiative to help package authors by submitting pull requests to public repositories that exhibit easily resolvable CRAN check issues, starting with “Lost braces” in documentation files.

**Next steps**

If the package uses roxygen2, you may wish to regenerate documentation to ensure future updates do not reintroduce these issues. Otherwise, the corrected .Rd files can be merged directly.